### PR TITLE
fix: BufferView: add missing casts in subview

### DIFF
--- a/include/libstored/fifo.h
+++ b/include/libstored/fifo.h
@@ -241,12 +241,12 @@ public:
 
 	BufferView subview(size_t offset, size_t len) const
 	{
-		return BufferView{*m_b, absolute(offset), absolute(offset + len)};
+		return BufferView{*m_b, absolute((pointer)offset), absolute((pointer)(offset + len))};
 	}
 
 	BufferView subview(size_t offset) const
 	{
-		return BufferView{*m_b, absolute(offset), m_to};
+		return BufferView{*m_b, absolute((pointer)offset), m_to};
 	}
 
 	void lstrip(size_t amount)


### PR DESCRIPTION
For a fixed capacity Buffer, the `pointer` is picked a small as possible to hold the required capacity. This means the type of `pointer` varies, sometimes it matches `size_t`, sometimes it does not...

In the `subview` functions this can cause a narrowing error (`size_t` -> `pointer`). Given that the pointer size is large enough to hold the lagest index, we can safely down-cast the arguments (`size_t`) to `pointer`, as required by the `absolute` helper function.